### PR TITLE
fix: missing dependency in `requirements.txt` and add `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+SynthesiaKontrol.egg-info/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 hidapi
 mido
 python-rtmidi
+cx_Freeze


### PR DESCRIPTION
# Description
`cx_Freeze` is included in the import part of `setup.py` while it is not in the `requirements.txt`. This PR adds this dependency to the requirements and also added a `.gitignore` file for omitting the build files and folders generated after running the build script.

# Information
After the merge, we will still need a new release as the v1.4 build with py310 is broken for some reason unknown. The v1.3 build is just fine with py3.7. And I tested with py312, the build is also good for use. So I really got no clue on this. For those who want to use immediately, here is a new build: [SynthesiaKontrol.v1.5.zip](https://github.com/user-attachments/files/31107143/SynthesiaKontrol.v1.5.zip) [VirusTotal Report](https://www.virustotal.com/gui/file/da8015a3445779440a409177c40153f0c0e12d48cf917e28ee609e9a2a7d7308/detection)

# Scope
Closes #36 #38

Thanks if you can take a look at this, @ojacques!