### PR TITLE
fix: replace quit()/exit() with sys.exit() for cx_Freeze compatibility

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,45 @@
+name: Build Windows Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build with cx_Freeze
+        run: python setup.py build
+
+      - name: Create zip archive
+        run: |
+          $buildDir = Get-ChildItem -Path build -Directory | Select-Object -First 1
+          Compress-Archive -Path "$($buildDir.FullName)\*" -DestinationPath "SynthesiaKontrol.v${{ github.ref_name }}.zip"
+        shell: pwsh
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SynthesiaKontrol-windows
+          path: SynthesiaKontrol.v*.zip
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: SynthesiaKontrol.v*.zip
+          generate_release_notes: true

--- a/SynthesiaKontrol.py
+++ b/SynthesiaKontrol.py
@@ -5,6 +5,7 @@
 # Synthesia Kontrol: an app to light the keys of Native Instruments
 #                    Komplete Kontrol MK2 keyboard, driven by Synthesia
 
+import sys
 import time
 import hid
 import mido
@@ -26,7 +27,7 @@ def init():
         device.open(NATIVE_INSTRUMENTS, INSTR_ADDR)
     except Exception as e:
         print("Error: " + str(e))
-        quit()
+        sys.exit(1)
 
     # Write 3 bytes to the device: 0xa0, 0x00, 0x00
     # Thanks to @xample for investigating this
@@ -50,7 +51,7 @@ def notes_off():
         device.write([0x82] + bufferC)
     else:
         print("Error: unsupported mode - should be MK1 or MK2")
-        quit()
+        sys.exit(1)
 
 
 def accept_notes(port):
@@ -127,7 +128,7 @@ def LightNote(note, status, channel, velocity):
         right_thumb = [0x00] + [0x80] + [0x00]   # Lighter Green
     else:
         print("Error: unsupported mode - should be MK1 or MK2")
-        quit()
+        sys.exit(1)
 
     default = right
     color = default
@@ -226,7 +227,7 @@ if __name__ == '__main__':
     else:
         print("Got '" + keyboard +
               "' - please type a number which corresponds to your keyboard, then Enter")
-        quit()
+        sys.exit(1)
 
     print("Connecting to Komplete Kontrol Keyboard")
     connected = init()
@@ -242,7 +243,7 @@ if __name__ == '__main__':
                 portName = port
         if portName == "":
             print("Error: can't find 'LoopBe' midi port. Please install LoopBe1 from http://www.nerds.de/en/download.html (Windows) or name your IAC midi device 'LoopBe' (on Mac).")
-            exit(1)
+            sys.exit(1)
 
         print("Listening to Midi on LoopBe midi port")
         with mido.open_input(portName) as midiPort:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ buildOptions = dict(
    
 setup(
     name = "SynthesiaKontrol",
-    version = "1.2",
+    version = "1.5",
     description = "Use Komplete Kontrol Keyboard lights in Synthesia",
     options = dict(build_exe = buildOptions),
     executables = executables


### PR DESCRIPTION
## Summary

Replace all `quit()` and `exit()` calls with `sys.exit()` to fix crashes in cx_Freeze frozen executables.

## Problem

The v1.4 release crashes with `NameError: name 'quit' is not defined` because `quit()` and `exit()` are interactive helpers from the `site` module that are not available in frozen executables.

## Changes

- Add `import sys` and replace all 5 occurrences of `quit()`/`exit(1)` with `sys.exit(1)`
- Bump version to 1.5 in `setup.py`
- Add GitHub Actions workflow for automated Windows builds (triggers on tag push `v*` or manual dispatch)

## Tested

- ✅ Linux build (Python 3.12, cx_Freeze 8.6.4)
- ✅ Windows build (Python 3.12.10, cx_Freeze 8.6.4)
- ✅ Smoke test: exe starts and `sys.exit(1)` works correctly

## Release

After merge, tag `v1.5` and the workflow will automatically build and publish the release.

Fixes #36, fixes #38