### PR TITLE
fix: dynamic buffer size for MK1 keyboards

### DIFF
--- a/SynthesiaKontrol.py
+++ b/SynthesiaKontrol.py
@@ -33,7 +33,7 @@ def init():
     # Thanks to @xample for investigating this
     device.write([0xa0, 0x00, 0x00])
 
-    bufferC = [0x00] * 249
+    bufferC = [0x00] * (3 * NB_KEYS if MODE == "MK1" else NB_KEYS)
     notes_off()
 
     return True
@@ -41,10 +41,11 @@ def init():
 
 def notes_off():
     """Turn off lights for all notes"""
+    global bufferC
 
     print("Turn off lights for all notes")
 
-    bufferC = [0x00] * 249
+    bufferC = [0x00] * (3 * NB_KEYS if MODE == "MK1" else NB_KEYS)
     if (MODE == "MK2"):
         device.write([0x81] + bufferC)
     elif (MODE == "MK1"):


### PR DESCRIPTION
## Problem

The light buffer was hardcoded to 249 bytes, but MK1 keyboards use 3 RGB bytes per key:
- S88 MK1: needs 3 × 88 = **264 bytes** → keys above ~83 could never light up
- This explains why many notes don't light on S88 MK1 (#22)

Additionally, `notes_off()` was missing `global bufferC`, so it created a local variable instead of clearing the shared buffer state. This caused stale light data to persist after `notes_off()` calls.

## Fix

- Buffer size is now computed dynamically: `3 * NB_KEYS` for MK1, `NB_KEYS` for MK2
- Added `global bufferC` to `notes_off()`

## Impact

Fixes light issues for all MK1 keyboards, especially S88 MK1 where the buffer was too small. MK2 keyboards are unaffected (they use 1 byte per key, max 88 bytes).

Fixes #22