### PR TITLE
feat: auto-detect keyboard, status panel, graceful shutdown

### DIFF
--- a/SynthesiaKontrol.py
+++ b/SynthesiaKontrol.py
@@ -1,25 +1,177 @@
 # The MIT License
 #
-# Copyright (c) 2018-2021 Olivier Jacques
+# Copyright (c) 2018-2025 Olivier Jacques
 #
 # Synthesia Kontrol: an app to light the keys of Native Instruments
 #                    Komplete Kontrol MK2 keyboard, driven by Synthesia
 
+import os
 import sys
 import time
+import signal
+import platform
+import subprocess
 import hid
 import mido
 
 NATIVE_INSTRUMENTS = 0x17cc
+
+# ---------------------------------------------------------------------------
+# Supported keyboards: product_id -> config
+# To add a new model, add a single entry here.
+# ---------------------------------------------------------------------------
+KEYBOARDS = {
+    0x1620: {"name": "Komplete Kontrol S61 MK2", "mode": "MK2", "keys": 61, "offset": -36, "menu": "1"},
+    0x1630: {"name": "Komplete Kontrol S88 MK2", "mode": "MK2", "keys": 88, "offset": -21, "menu": "2"},
+    0x1610: {"name": "Komplete Kontrol S49 MK2", "mode": "MK2", "keys": 49, "offset": -36, "menu": "3"},
+    0x1360: {"name": "Komplete Kontrol S61 MK1", "mode": "MK1", "keys": 61, "offset": -36, "menu": "4"},
+    0x1410: {"name": "Komplete Kontrol S88 MK1", "mode": "MK1", "keys": 88, "offset": -21, "menu": "5"},
+    0x1350: {"name": "Komplete Kontrol S49 MK1", "mode": "MK1", "keys": 49, "offset": -36, "menu": "6"},
+    0x1340: {"name": "Komplete Kontrol S25 MK1", "mode": "MK1", "keys": 25, "offset": -21, "menu": "7"},
+}
+
+MENU_TO_PID = {cfg["menu"]: pid for pid, cfg in KEYBOARDS.items()}
+
+# Runtime state (set after keyboard selection)
+MODE = "MK2"
 INSTR_ADDR = 0x1620
 NB_KEYS = 61
-MODE = "MK2"
+OFFSET = -36
+device = None
+bufferC = None
 
+
+# ---------------------------------------------------------------------------
+# Auto-detection
+# ---------------------------------------------------------------------------
+
+def detect_keyboards():
+    """Return list of supported keyboards currently connected via USB HID."""
+    found = {}
+    try:
+        for dev in hid.enumerate(NATIVE_INSTRUMENTS):
+            pid = dev.get("product_id")
+            if pid in KEYBOARDS and pid not in found:
+                cfg = KEYBOARDS[pid].copy()
+                cfg["product_id"] = pid
+                found[pid] = cfg
+    except Exception:
+        pass
+    return list(found.values())
+
+
+def apply_keyboard_config(cfg):
+    """Apply a keyboard config dict to global state."""
+    global MODE, INSTR_ADDR, NB_KEYS, OFFSET
+    MODE = cfg["mode"]
+    INSTR_ADDR = cfg["product_id"]
+    NB_KEYS = cfg["keys"]
+    OFFSET = cfg["offset"]
+
+
+def select_keyboard():
+    """Auto-detect keyboard or fall back to interactive menu."""
+    detected = detect_keyboards()
+
+    if len(detected) == 1:
+        cfg = detected[0]
+        apply_keyboard_config(cfg)
+        print(f"  Auto-detected: {cfg['name']} ({cfg['keys']} keys, {cfg['mode']})")
+        return True
+
+    if len(detected) > 1:
+        print("  Multiple keyboards found — pick one:")
+        for i, cfg in enumerate(detected, start=1):
+            print(f"    {i}) {cfg['name']}")
+        choice = input("  Your choice: ").strip()
+        try:
+            idx = int(choice) - 1
+            if 0 <= idx < len(detected):
+                apply_keyboard_config(detected[idx])
+                return True
+        except ValueError:
+            pass
+        print("  Invalid selection.")
+        return False
+
+    # Nothing detected — manual menu (same as before)
+    print("Select your keyboard (1, 2, 3, ...) and press 'Enter':")
+    for pid, cfg in sorted(KEYBOARDS.items(), key=lambda x: int(x[1]["menu"])):
+        print(f"  {cfg['menu']}-{cfg['name']}")
+    keyboard = input()
+
+    if keyboard in MENU_TO_PID:
+        pid = MENU_TO_PID[keyboard]
+        cfg = KEYBOARDS[pid].copy()
+        cfg["product_id"] = pid
+        apply_keyboard_config(cfg)
+        return True
+    else:
+        print("Got '" + keyboard +
+              "' - please type a number which corresponds to your keyboard, then Enter")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Status checks
+# ---------------------------------------------------------------------------
+
+def is_synthesia_running():
+    """Return True if a Synthesia process is running."""
+    try:
+        if platform.system() == "Windows":
+            result = subprocess.run(
+                ["tasklist", "/FI", "IMAGENAME eq Synthesia.exe", "/NH"],
+                capture_output=True, text=True,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            return "synthesia.exe" in (result.stdout or "").lower()
+        else:
+            result = subprocess.run(
+                ["pgrep", "-if", "synthesia"],
+                capture_output=True, text=True,
+            )
+            return result.returncode == 0
+    except Exception:
+        return False
+
+
+def find_loopbe_port():
+    """Return LoopBe MIDI input port name, or empty string if not found."""
+    try:
+        for port in mido.get_input_names():
+            if "LoopBe" in port:
+                return port
+    except Exception:
+        pass
+    return ""
+
+
+def print_status():
+    """Print startup status panel."""
+    print()
+    print("── Status ──────────────────────────────────────────")
+    synth = is_synthesia_running()
+    loopbe = find_loopbe_port()
+    print(f"  Synthesia:  {'running' if synth else 'NOT running'}")
+    print(f"  LoopBe:     {loopbe if loopbe else 'NOT found'}")
+    print(f"  Keyboard:   {KEYBOARDS.get(INSTR_ADDR, {}).get('name', 'Unknown')}")
+    print("────────────────────────────────────────────────────")
+    if not synth:
+        print()
+        print("  Tip: Start Synthesia, set Music Output -> LoopBe")
+        print("       with 'Finger-based channel' key lights.")
+    print()
+    return loopbe
+
+
+# ---------------------------------------------------------------------------
+# Device / lighting
+# ---------------------------------------------------------------------------
 
 def init():
-    """Connect to the keyboard, switch all lights off"""
-    global bufferC  # Buffer with the full key/lights mapping
-    global device
+    """Connect to the keyboard, switch all lights off."""
+    global bufferC, device
 
     print("Opening Keyboard device...")
     device = hid.device()
@@ -29,8 +181,7 @@ def init():
         print("Error: " + str(e))
         sys.exit(1)
 
-    # Write 3 bytes to the device: 0xa0, 0x00, 0x00
-    # Thanks to @xample for investigating this
+    # Enter light-guide mode (thanks @xample)
     device.write([0xa0, 0x00, 0x00])
 
     bufferC = [0x00] * (3 * NB_KEYS if MODE == "MK1" else NB_KEYS)
@@ -40,19 +191,28 @@ def init():
 
 
 def notes_off():
-    """Turn off lights for all notes"""
+    """Turn off lights for all notes."""
     global bufferC
-
-    print("Turn off lights for all notes")
-
     bufferC = [0x00] * (3 * NB_KEYS if MODE == "MK1" else NB_KEYS)
-    if (MODE == "MK2"):
+    if MODE == "MK2":
         device.write([0x81] + bufferC)
-    elif (MODE == "MK1"):
+    elif MODE == "MK1":
         device.write([0x82] + bufferC)
     else:
         print("Error: unsupported mode - should be MK1 or MK2")
         sys.exit(1)
+
+
+def shutdown(signum=None, frame=None):
+    """Graceful shutdown: turn lights off and exit."""
+    print()
+    print("Shutting down — lights off...")
+    try:
+        notes_off()
+    except Exception:
+        pass
+    print("Bye!")
+    sys.exit(0)
 
 
 def accept_notes(port):
@@ -71,184 +231,140 @@ def accept_notes(port):
 
 
 def CoolDemoSweep(loopcount):
+    """Startup light sweep animation."""
     speed = 0.01
-    for loop in range(0, loopcount):
+    for _ in range(loopcount):
         # Forward
-        for x in range(0, NB_KEYS-3):
-            if (MODE == "MK2"):
-                bufferC = [0x00] * NB_KEYS
-                bufferC[0] = 0x81
-                bufferC[x] = (0x04 + x % 4)
-                bufferC[x+1] = (0x08 + x % 4)
-                bufferC[x+2] = (0x0c + x % 4)
-                bufferC[x+3] = (0x10 + x % 4)
+        for x in range(0, NB_KEYS - 3):
+            if MODE == "MK2":
+                buf = [0x00] * NB_KEYS
+                buf[x] = 0x04 + x % 4
+                buf[x + 1] = 0x08 + x % 4
+                buf[x + 2] = 0x0c + x % 4
+                buf[x + 3] = 0x10 + x % 4
+                device.write([0x81] + buf)
             else:
-                bufferC = [0x00] * 3 * NB_KEYS
-                bufferC[0] = 0x82
-                bufferC[x*3-2] = 0xFF
-            device.write(bufferC)
+                buf = [0x00] * (3 * NB_KEYS)
+                buf[x * 3] = 0xFF
+                device.write([0x82] + buf)
             time.sleep(speed)
         # Backward
         for x in range(NB_KEYS - 1, 0, -1):
-            if (MODE == "MK2"):
-                bufferC = [0x00] * NB_KEYS
-                bufferC[0] = 0x81
-                bufferC[x] = (0x2c + x % 4)
-                bufferC[x-1] = (0x2d + x % 4)
-                bufferC[x-2] = (0x2e + x % 4)
-                bufferC[x-3] = (0x2f + x % 4)
+            if MODE == "MK2":
+                buf = [0x00] * NB_KEYS
+                buf[x] = 0x2c + x % 4
+                buf[x - 1] = 0x2d + x % 4
+                buf[x - 2] = 0x2e + x % 4
+                buf[x - 3] = 0x2f + x % 4
+                device.write([0x81] + buf)
             else:
-                bufferC = [0x00] * 3 * NB_KEYS
-                bufferC[0] = 0x82
-                bufferC[x*3-2] = 0xFF
-            device.write(bufferC)
+                buf = [0x00] * (3 * NB_KEYS)
+                buf[x * 3] = 0xFF
+                device.write([0x82] + buf)
             time.sleep(speed)
     notes_off()
 
 
 def LightNote(note, status, channel, velocity):
-    """Light a note ON or OFF"""
-
-    # bufferC[0] = 0x81    # For Komplete Kontrol MK2
-    offset = OFFSET
-    key = (note + offset)
+    """Light a note ON or OFF."""
+    key = note + OFFSET
 
     if key < 0 or key >= NB_KEYS:
         return
 
     # Determine color
-    if (MODE == "MK2"):
-        left = 0x2d   # Blue
-        left_thumb = 0x2f   # Lighter Blue
-        right = 0x1d   # Green
-        right_thumb = 0x1f   # Lighter Green
-    elif (MODE == "MK1"):
-        left = [0x00] + [0x00] + [0xFF]   # Blue
-        left_thumb = [0x00] + [0x00] + [0x80]   # Lighter Blue
-        right = [0x00] + [0xFF] + [0x00]   # Green
-        right_thumb = [0x00] + [0x80] + [0x00]   # Lighter Green
+    if MODE == "MK2":
+        left = 0x2d        # Blue
+        left_thumb = 0x2f  # Lighter Blue
+        right = 0x1d       # Green
+        right_thumb = 0x1f # Lighter Green
+    elif MODE == "MK1":
+        left = [0x00, 0x00, 0xFF]        # Blue
+        left_thumb = [0x00, 0x00, 0x80]  # Lighter Blue
+        right = [0x00, 0xFF, 0x00]       # Green
+        right_thumb = [0x00, 0x80, 0x00] # Lighter Green
     else:
         print("Error: unsupported mode - should be MK1 or MK2")
         sys.exit(1)
 
-    default = right
-    color = default
+    color = right  # default
 
-    # Finger based channel protocol from Synthesia
+    # Finger-based channel protocol from Synthesia
     # Reference: https://www.synthesiagame.com/forum/viewtopic.php?p=43585#p43585
     if channel == 0:
-        # we don't know who or what this note belongs to, but light something up anyway
-        color = default
-    if channel >= 1 and channel <= 5:
-        # left hand fingers, thumb through pinky
-        if channel == 1:
-            color = left_thumb
-        else:
-            color = left
-    if channel >= 6 and channel <= 10:
-        # right hand fingers, thumb through pinky
-        if channel == 6:
-            color = right_thumb
-        else:
-            color = right
-    if channel == 11:
-        # left hand, unknown finger
+        color = right
+    elif 1 <= channel <= 5:
+        color = left_thumb if channel == 1 else left
+    elif 6 <= channel <= 10:
+        color = right_thumb if channel == 6 else right
+    elif channel == 11:
         color = left
-    if channel == 12:
-        # right hand, unknown finger
+    elif channel == 12:
         color = right
 
     if status == 'note_on' and velocity != 0:
-        if (MODE == "MK2"):
-            bufferC[key] = color     # Set color
+        if MODE == "MK2":
+            bufferC[key] = color
         else:
-            bufferC[3*key:3*key+3] = color
-    if (status == 'note_off' or velocity == 0):
-        # Note off or velocity 0 (equals note off)
-        if (MODE == "MK2"):
-            bufferC[key] = 0x00      # Switch key light off
+            bufferC[3 * key:3 * key + 3] = color
+    if status == 'note_off' or velocity == 0:
+        if MODE == "MK2":
+            bufferC[key] = 0x00
         else:
-            bufferC[3*key:3*key+3] = [0x00] * 3
+            bufferC[3 * key:3 * key + 3] = [0x00] * 3
 
-    if (MODE == "MK2"):
+    if MODE == "MK2":
         device.write([0x81] + bufferC)
     else:
         device.write([0x82] + bufferC)
 
 
-if __name__ == '__main__':
-    """Main: connect to keyboard, open midi input port, listen to midi"""
-    print("Select your keyboard (1, 2, 3, ...) and press 'Enter':")
-    print("  1-Komplete Kontrol S61 MK2")
-    print("  2-Komplete Kontrol S88 MK2")
-    print("  3-Komplete Kontrol S49 MK2")
-    print("  4-Komplete Kontrol S61 MK1")
-    print("  5-Komplete Kontrol S88 MK1")
-    print("  6-Komplete Kontrol S49 MK1")
-    print("  7-Komplete Kontrol S25 MK1")
-    keyboard = input()
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
-    # Customize here for new keyboards
-    # Pull requests welcome!
-    if keyboard == "1":
-        MODE = "MK2"
-        INSTR_ADDR = 0x1620  # KK S61 MK2
-        NB_KEYS = 61
-        OFFSET = -36
-    elif keyboard == "2":
-        MODE = "MK2"
-        INSTR_ADDR = 0x1630  # KK S88 MK2
-        NB_KEYS = 88
-        OFFSET = -21
-    elif keyboard == "3":
-        MODE = "MK2"
-        INSTR_ADDR = 0x1610  # KK S49 MK2
-        NB_KEYS = 49
-        OFFSET = -36
-    elif keyboard == "4":
-        MODE = "MK1"
-        INSTR_ADDR = 0x1360  # KK S61 MK1
-        NB_KEYS = 61
-        OFFSET = -36
-    elif keyboard == "5":
-        MODE = "MK1"
-        INSTR_ADDR = 0x1410  # KK S88 MK1
-        NB_KEYS = 88
-        OFFSET = -21
-    elif keyboard == "6":
-        MODE = "MK1"
-        INSTR_ADDR = 0x1350  # KK S49 MK1
-        NB_KEYS = 49
-        OFFSET = -36
-    elif keyboard == "7":
-        MODE = "MK1"
-        INSTR_ADDR = 0x1340  # KK S25 MK1
-        NB_KEYS = 25
-        OFFSET = -21
-    else:
-        print("Got '" + keyboard +
-              "' - please type a number which corresponds to your keyboard, then Enter")
+if __name__ == '__main__':
+    print("SynthesiaKontrol — Komplete Kontrol light guide bridge")
+    print()
+
+    # Select keyboard (auto-detect or manual)
+    if not select_keyboard():
         sys.exit(1)
 
+    # Show status
+    loopbe_port = print_status()
+
+    # Connect to keyboard
     print("Connecting to Komplete Kontrol Keyboard")
     connected = init()
-    portName = ""
+
     if connected:
+        # Register graceful shutdown (Ctrl+C)
+        signal.signal(signal.SIGINT, shutdown)
+        if hasattr(signal, 'SIGTERM'):
+            signal.signal(signal.SIGTERM, shutdown)
+
         print("Connected to Komplete Kontrol!")
         CoolDemoSweep(2)    # Happy dance
-        print("Opening LoopBe input port")
-        ports = mido.get_input_names()
-        for port in ports:
-            print("  Found MIDI port " + port + "...")
-            if "LoopBe" in port:
-                portName = port
-        if portName == "":
-            print("Error: can't find 'LoopBe' midi port. Please install LoopBe1 from http://www.nerds.de/en/download.html (Windows) or name your IAC midi device 'LoopBe' (on Mac).")
+
+        # Find LoopBe port
+        if not loopbe_port:
+            loopbe_port = find_loopbe_port()
+        if not loopbe_port:
+            print("Error: can't find 'LoopBe' midi port.")
+            print("  Install LoopBe1: http://www.nerds.de/en/download.html (Windows)")
+            print("  Or name your IAC midi device 'LoopBe' (macOS).")
             sys.exit(1)
 
-        print("Listening to Midi on LoopBe midi port")
-        with mido.open_input(portName) as midiPort:
-            for message in accept_notes(midiPort):
-                print('Received {}'.format(message))
-                LightNote(message.note, message.type,
-                          message.channel, message.velocity)
+        print(f"Listening to MIDI on: {loopbe_port}")
+        print("Press Ctrl+C to quit.")
+        print()
+
+        try:
+            with mido.open_input(loopbe_port) as midiPort:
+                for message in accept_notes(midiPort):
+                    print('Received {}'.format(message))
+                    LightNote(message.note, message.type,
+                              message.channel, message.velocity)
+        except KeyboardInterrupt:
+            shutdown()


### PR DESCRIPTION
## Summary

Modernizes the startup flow with auto-detection, status feedback, and clean shutdown.

## Changes

### KEYBOARDS dict (refactor)
Replaces the long if/elif chain with a single `KEYBOARDS` dict. Adding a new model is now one line.

### Auto-detect keyboard
Uses `hid.enumerate()` to find connected NI keyboards:
- **One found** → selected automatically (no prompt)
- **Multiple** → short list of only connected devices
- **None** → falls back to the original manual menu

### Status panel at startup
Shows whether Synthesia is running, LoopBe port is available, and which keyboard is selected. Provides a tip if Synthesia isn't running.

### Graceful Ctrl+C shutdown
Registers `SIGINT`/`SIGTERM` handlers that turn lights off before exiting. No more stuck LEDs.

### CoolDemoSweep fix
Uses a local `buf` variable instead of clobbering the global `bufferC`, preventing stale light data after the sweep.

## Tested
- ✅ Linux build (Python 3.12, cx_Freeze 8.6.4)
- ✅ Windows build (Python 3.12.10, cx_Freeze 8.6.4)
- ✅ Smoke test: exe starts, falls back to manual menu when no keyboard connected, exits cleanly

## Credits
Inspired by ideas from PR #42 (@Drdopak).