### PR TITLE
feat: add --transpose option to shift light guide

### DIFF
--- a/SynthesiaKontrol.py
+++ b/SynthesiaKontrol.py
@@ -5,6 +5,7 @@
 # Synthesia Kontrol: an app to light the keys of Native Instruments
 #                    Komplete Kontrol MK2 keyboard, driven by Synthesia
 
+import argparse
 import os
 import sys
 import time
@@ -324,12 +325,26 @@ def LightNote(note, status, channel, velocity):
 # ---------------------------------------------------------------------------
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="SynthesiaKontrol — Komplete Kontrol light guide bridge"
+    )
+    parser.add_argument(
+        "--transpose", "-t", type=int, default=0,
+        help="Shift the light guide by N semitones (e.g., --transpose 12 for +1 octave)"
+    )
+    args = parser.parse_args()
+
     print("SynthesiaKontrol — Komplete Kontrol light guide bridge")
     print()
 
     # Select keyboard (auto-detect or manual)
     if not select_keyboard():
         sys.exit(1)
+
+    # Apply transpose offset
+    if args.transpose != 0:
+        OFFSET += args.transpose
+        print(f"  Transpose: {args.transpose:+d} semitones (OFFSET = {OFFSET})")
 
     # Show status
     loopbe_port = print_status()


### PR DESCRIPTION
## Problem

On S49/S25, when you transpose (octave +/-) in Synthesia, the MIDI note numbers shift but the light guide stays fixed — lights appear on wrong keys or don't show at all (#32).

## Solution

Adds a `--transpose` / `-t` command-line argument to shift the light offset by N semitones:

```bash
python SynthesiaKontrol.py --transpose 12   # +1 octave
python SynthesiaKontrol.py -t -12           # -1 octave
```

The value is added to the keyboard's default OFFSET at startup.

## Why not auto-detect?

Synthesia doesn't send a MIDI CC when the user transposes, so there's no way to detect it automatically. A manual argument is the simplest reliable approach.

Fixes #32